### PR TITLE
implement rigged roll functionality

### DIFF
--- a/routes/api/roll.tsx
+++ b/routes/api/roll.tsx
@@ -1,0 +1,77 @@
+import { GroupmeCallback } from "../../types/groupmeCallback.ts";
+import probabilities from "../../static/rollProbabilities.json" assert { type: "json" } 
+import chatBank from "../../static/chatBank.json" assert {type: "json"}
+import {templateIncludesText} from "../api/gmCallback.tsx"
+
+/**
+ * implements a rigged roll based on the person who sent the roll request to the groupme
+ * 
+ * @param message - the GroupmeCallback object which encapsulates the message and the sender, among other things
+ */
+export function specialRoll(message : GroupmeCallback): string {
+    // attempt to find the sender in the people listed
+    const sender = probabilities.people.find(sender => sender.id == message.sender_id)
+
+    // if the person was found, use their probability space, otherwise do a normal roll
+    if (sender){
+        var probability = sender.probability;
+    }else{
+        // the person was not found
+        var probability = "default";
+    }
+
+    // to do the roll, we need to figure out which number they were attempting to land (if possible)
+    // find the keyword that was triggered and extract the landing number from there
+
+    // find the keyword
+    const matchingTemplate = chatBank.templates.find(template => templateIncludesText(message.text, template));
+    const keywordMatch = matchingTemplate ? matchingTemplate.keywords.find(keyword => message.text.toLowerCase().includes(keyword.toLowerCase())) : "";
+
+    // extract the landing number
+    const key = {
+        "on a 1": 1,
+        "on a one": 1,
+        "on a 2": 2,
+        "on a two": 2,
+        "on a 3": 3,
+        "on a three": 3,
+        "on a 4": 4,
+        "on a four": 4,
+        "on a 5": 5,
+        "on a five": 5,
+        "on a 6": 6,
+        "on a six": 6
+    }    
+    const landingNumber = keywordMatch ? key[keywordMatch] : undefined;
+
+    // if there's no landing number, just do the roll like normal
+    if (!landingNumber) return ["1", "2", "3", "4", "4", "5", "6", "20"][Math.floor(Math.random() * 7)];
+
+    // decide if the roll lands, doesn't, or bounces back
+    var space = probabilities.probability_spaces.find(space => space.title == probability)
+    var outcome = "undecided";
+    if (space){
+        const totalSpace = space.dist.bounceback + space.dist.land + space.dist.miss
+        var rollFactor = Math.random() * totalSpace
+
+        if (rollFactor < space.dist.bounceback){
+            outcome = "bounceback";
+        }else if (rollFactor < space.dist.bounceback + space.dist.land){
+            outcome = "land";
+        }else {
+            outcome = "miss";
+        }
+
+        switch (outcome){
+            case "bounceback":
+                return "20";
+            case "land":
+                return landingNumber;
+            case "miss":
+                return ["1", "2", "3", "4", "5", "6"].filter(num => num != landingNumber)[Math.floor(Math.random() * 5)];
+        }
+    }else{
+        // if for some reason, somebody is listed with a probability that doesn't exist, do a normal roll.
+        return ["1", "2", "3", "4", "4", "5", "6", "20"][Math.floor(Math.random() * 7)];
+    }
+}

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -3,26 +3,45 @@ import { h } from "preact";
 import { tw } from "@twind";
 import { Handlers, PageProps } from "$fresh/server.ts";
 import { getResponseForMessage } from "./api/gmCallback.tsx";
+import { groupmeCallback } from "../types/groupmeCallback.ts"
 
 interface Data {
   roboResp: string | undefined;
   msg: string;
+  acctId: string;
 }
 
 export const handler: Handlers<Data> = {
   GET(req, ctx) {
-    const url =new URL(req.url)
+    const url = new URL(req.url)
     const msg = url.searchParams.get("msg") || "";
-    
+    const acctId = url.searchParams.get("account") || "";
+
     // simulate robo ape response using same function (without posting)
-    const roboResp = getResponseForMessage(msg);
-    
-    return ctx.render({roboResp, msg});
+    var messageObj: groupmeCallback;
+    messageObj = {
+      attachments: [],
+      avatar_url: "",
+      created_at: "",
+      group_id: "",
+      id: "",
+      name: "",
+      sender_id: acctId,
+      sender_type: "",
+      source_guid: "",
+      system: "",
+      text: msg,
+      user_id: ""
+    }
+
+    const roboResp = getResponseForMessage(messageObj);
+
+    return ctx.render({ roboResp, msg });
   }
 }
 
-export default function Home({ data }: PageProps<Data> ) {
-  const { roboResp, msg } = data;
+export default function Home({ data }: PageProps<Data>) {
+  const { roboResp, msg, acctId } = data;
   return (
     <div class={tw`h-screen p-10 flex flex-col bg-gradient-to-b from-yellow-200 via-green-200 to-green-300`}>
       <div class={tw`flex-auto h-full`}>
@@ -31,7 +50,7 @@ export default function Home({ data }: PageProps<Data> ) {
             welcome to the robo ape zone
           </h2>
           <h6 class={tw`text-md font-light italic`}>
-              is it comfortable here?
+            is it comfortable here?
           </h6>
         </div>
 
@@ -40,23 +59,28 @@ export default function Home({ data }: PageProps<Data> ) {
             robo ape may respond thusly:
           </h2>
           <h6 class={tw`max-w-md p-5 text-md font-light italic font-serif ${roboResp ? '' : 'text-pink-800'} bg-gray-50 rounded border-gray-300`}>
-              {
-                roboResp ? `"${roboResp}"` : "ROBO APE would not respond to this, out of poor mood or ignorance"
-              }
+            {
+              roboResp ? `"${roboResp}"` : "ROBO APE would not respond to this, out of poor mood or ignorance"
+            }
           </h6>
         </div>}
-        
+
         <div class={tw`p-10 mt-3 w-100 text-left`}>
           <form>
             <p class={tw`mb-2 font-semibold`}>
               enter your test message:
             </p>
-            <input type="text" name="msg" value={msg} class={tw`p-2 rounded border mr-3`}/>
+            <input type="text" name="msg" value={msg} class={tw`p-2 rounded border mr-3`} />
             <button type="submit" class={tw`p-2 bg-gray-300 rounded`}>see what ape say</button>
+            <select name="account" value={acctId} class={tw`p-2 bg-blue-800 rounded text-white`}>
+              <option value="default">rando</option>
+              <option value="123456">luke</option>
+              <option value="sonny">sonny</option>
+            </select>
           </form>
-          
+
         </div>
-        
+
       </div>
       <footer class={tw`text-center text-purple-800 underline `}>
         <a href="https://github.com/sambskn/roboape-edge" target="_blank" rel="noopener noreferrer">see inside roboape</a>

--- a/static/chatBank.json
+++ b/static/chatBank.json
@@ -62,7 +62,7 @@
 
 			],
 			"frequency":1.0,
-			"special": null
+			"special": "roll"
 		},
 		{
 			"keywords": [

--- a/static/rollProbabilities.json
+++ b/static/rollProbabilities.json
@@ -1,0 +1,53 @@
+{
+    "people": [
+        {
+            "firstname": "Luke",
+            "lastname" : "Terry",
+            "id" : "123456",
+            "probability": "lucky"
+        }
+    ],
+
+    "probability_spaces": [
+        {
+            "title": "alumni",
+            "dist" : {
+                "land" : 0.25,
+                "miss": 0.7,
+                "bounceback" : 0.05
+            }
+        },
+        {
+            "title": "lucky",
+            "dist" : {
+                "land" : 0.2,
+                "miss": 0.7,
+                "bounceback" : 0.1
+            }
+        },
+        {
+            "title": "unlucky",
+            "dist" : {
+                "land" : 0.1,
+                "miss": 0.7,
+                "bounceback" : 0.2
+            }
+        },
+        {
+            "title": "fucked",
+            "dist" : {
+                "land" : 0.05,
+                "miss": 0.7,
+                "bounceback" : 0.25
+            }
+        },
+        {
+            "title": "default",
+            "dist" : {
+                "land": 0.15,
+                "miss" : 0.71,
+                "bounceback": 0.14
+            }
+        }
+    ]
+}


### PR DESCRIPTION
I have implemented a way for the program to recognize who is sending a message for a roll, and make their roll behave with a custom probability distribution.

To make it work in practice, we will have to eventually collect the user_id of everyone who has a custom distribution. People not recorded or without a number to land on (if they say "roll a die" instead of "on a 4") will just receive a standard dice roll