### PR TITLE
Fix bug with "on a 4"

### DIFF
--- a/routes/api/roll.tsx
+++ b/routes/api/roll.tsx
@@ -80,7 +80,8 @@ export function specialRoll(message : GroupmeCallback): string {
             case "land":
                 return desiredNumber;
             case "miss":
-                return NORMAL_ROLL_OPTIONS.filter(num => num != desiredNumber)[Math.floor(getRandomProbability() * (NORMAL_ROLL_OPTIONS.length -1))];
+                const MISSES = NORMAL_ROLL_OPTIONS.filter(num => num != desiredNumber);
+                return MISSES[Math.floor(getRandomProbability() * (MISSES.length - 1))];
         }
     }
     
@@ -90,5 +91,5 @@ export function specialRoll(message : GroupmeCallback): string {
 }
 
 const getDefaultRoll = (): string => {
-    return ROLL_OPTIONS[Math.floor(getRandomProbability() * ROLL_OPTIONS.length)]
+    return ROLL_OPTIONS[Math.floor(getRandomProbability() * ROLL_OPTIONS.length)];
 }


### PR DESCRIPTION
Since the roll probabilities previously chose a random number from `NORMAL_ROLL_OPTIONS.length`, and there were two fours in the normal roll options, rolling "on a 4" occassionally caused the program to return undefined (by accessing an index outside of the filtered roll options array). This caused roboape to rudely ignore my rolls.

This bug fix just stores the actual values in a variable and accesses them, fixing the problem. 