### PR TITLE
enhances rolls with a mention of the corresponding user who rolled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+deno.lock

--- a/routes/api/gmCallback.tsx
+++ b/routes/api/gmCallback.tsx
@@ -30,7 +30,7 @@ export const handler: Handlers = {
 
         // check to make sure the bot is not responding to itself
         if (reqBody.name !== BOT_NAME) {
-            var response = getResponseForMessage(reqBody);
+            const response = getResponseForMessage(reqBody);
             if (response) {
                 const botID = await getBotIdForMessage(reqBody);
                 // Post to groupme

--- a/routes/api/gmCallback.tsx
+++ b/routes/api/gmCallback.tsx
@@ -65,7 +65,7 @@ export function getResponseForMessage(msg: GroupmeCallback): RoboResponse | unde
         // Randomly select response from responses
         const response: RoboResponse = {
             message: matchingTemplate?.responses[Math.floor(getRandomProbability() * matchingTemplate.responses.length)],
-            attachments: ""
+            attachments: []
         } 
         return response;
         }

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -34,7 +34,7 @@ export const handler: Handlers<Data> = {
     }
 
     const roboResp = getResponseForMessage(messageObj);
-    
+
     return ctx.render({ roboResp, msg, acctId });
   }
 }
@@ -84,9 +84,9 @@ export default function Home({ data }: PageProps<Data>) {
           <h2 class={tw`mb-2 font-semibold`}>
             robo ape may respond thusly:
           </h2>
-          <h6 class={tw`max-w-md p-5 text-md font-light italic font-serif ${roboResp.message ? '' : 'text-pink-800'} bg-gray-50 rounded border-gray-300`}>
+          <h6 class={tw`max-w-md p-5 text-md font-light italic font-serif ${roboResp ? '' : 'text-pink-800'} bg-gray-50 rounded border-gray-300`}>
             {
-              roboResp.message ? `"${roboResp.message}"` : "ROBO APE would not respond to this, out of poor mood or ignorance"
+              roboResp ? `"${roboResp.message}"` : "ROBO APE would not respond to this, out of poor mood or ignorance"
             }
           </h6>
         </div>}

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -24,7 +24,7 @@ export const handler: Handlers<Data> = {
       created_at: 0,
       group_id: "",
       id: "",
-      name: "",
+      name: "Robert",
       sender_id: acctId,
       sender_type: "",
       source_guid: "",
@@ -34,7 +34,7 @@ export const handler: Handlers<Data> = {
     }
 
     const roboResp = getResponseForMessage(messageObj);
-
+    
     return ctx.render({ roboResp, msg, acctId });
   }
 }
@@ -84,9 +84,9 @@ export default function Home({ data }: PageProps<Data>) {
           <h2 class={tw`mb-2 font-semibold`}>
             robo ape may respond thusly:
           </h2>
-          <h6 class={tw`max-w-md p-5 text-md font-light italic font-serif ${roboResp ? '' : 'text-pink-800'} bg-gray-50 rounded border-gray-300`}>
+          <h6 class={tw`max-w-md p-5 text-md font-light italic font-serif ${roboResp.message ? '' : 'text-pink-800'} bg-gray-50 rounded border-gray-300`}>
             {
-              roboResp ? `"${roboResp}"` : "ROBO APE would not respond to this, out of poor mood or ignorance"
+              roboResp.message ? `"${roboResp.message}"` : "ROBO APE would not respond to this, out of poor mood or ignorance"
             }
           </h6>
         </div>}

--- a/types/roboResponse.ts
+++ b/types/roboResponse.ts
@@ -1,0 +1,6 @@
+// A helpful type to pass additional information (like @'s)
+// along with the message text in a response.
+export type RoboResponse = {
+    message: string;
+    attachments: any;
+};


### PR DESCRIPTION
I found a thread on Google groups discussing adding mentions to bot responses [here](https://groups.google.com/g/groupme-api-support/c/mNyIZB_S1jc).

I have added support for mentioning a user when responding to a roll. This behaves well in the **robo ape zone**, but I have not been able to test this in GroupMe itself. ¯\_(ツ)_/¯ It probably works tho.